### PR TITLE
Include pause wave count options

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -168,7 +168,15 @@ class Params
 		texts[] = {"0", "15 Seconds", "30 Seconds", "1 Minute", "1 Minute 30 Seconds", "2 Minutes", "3 Minutes", "4 Minutes", "5 Minutes"};
 		default = 30;
 	};
-
+	
+	class PAUSE_WAVE_COUNTER
+	{
+		title = "Pause Mission every X number waves";
+		values[] = {0, 1, 2, 5, 10};
+		texts[] = {"Disabled", "1", "2", "5", "10"};
+		default = 5;
+	}
+	
 	class BULWARK_MEDIKIT
 	{
 		title = "Medikits in Bulwark";

--- a/editMe.sqf
+++ b/editMe.sqf
@@ -94,3 +94,6 @@ if (DAY_TIME_FROM > DAY_TIME_TO) then {
 
 /* Starter MediKits */
 BULWARK_MEDIKITS = ("BULWARK_MEDIKIT" call BIS_fnc_getParamValue);
+
+/* Pause Wave increment */
+PAUSE_WAVE_COUNT = ("PAUSE_WAVE_COUNTER" call BIS_fnc_getParamValue);

--- a/initServer.sqf
+++ b/initServer.sqf
@@ -23,6 +23,7 @@ publicVariable "PLAYER_STARTMAP";
 publicVariable "PLAYER_STARTNVG";
 publicVariable "PISTOL_HOSTILES";
 publicVariable "DOWN_TIME";
+publicVariable "PAUSE_WAVE_COUNT";
 
 _dayTimeHours = DAY_TIME_TO - DAY_TIME_FROM;
 _randTime = floor random _dayTimeHours;

--- a/missionLoop.sqf
+++ b/missionLoop.sqf
@@ -8,6 +8,12 @@ publicVariable "attkWave";
 activeLoot = [];
 //mrkrs = [];
 
+pauseWave = false;
+WAVE_PAUSED = false;
+
+publicVariable "pauseWave";
+publicVariable "WAVE_PAUSED";
+
 waveUnits = [[],[],[]];
 revivedPlayers = [];
 
@@ -141,5 +147,35 @@ while {runMissionLoop} do {
 		};
 	} foreach allPlayers;
 
+	
+	//Pause mission loop every X waves
+		if (attkWave%PAUSE_WAVE_COUNT == 0 && PAUSE_WAVE_COUNT != 0) then {
+			//Pause mission loop 
+			WAVE_PAUSED = true;
+					
+			//notification to players
+			["<t size = '.8'>Hostile Waves Paused.</t>",0, 0.1, 3, 0] remoteExec ["BIS_fnc_dynamicText", 0];
+			//add menu item to bulwark
+			[bulwarkBox, ["<t color='#9e2403'>" + "Resume Waves.","bulwark\resumeWave.sqf" ,"",3,false,true,"true","true",2.5]] remoteExec ["addAction", 0, true];
+		};
+		
+		while {WAVE_PAUSED} do {
+		
+			{
+			// Try to force the spectator mode off when players are revived.
+				["Terminate"] remoteExec ["BIS_fnc_EGSpectator", _x];
+
+				// Revive players that died during the pause wave.
+				if ((lifeState _x == "DEAD") || (lifeState _x == "INCAPACITATED")) then {
+				forceRespawn _x;
+				};		
+				} foreach allPlayers;	
+				sleep 5;
+			};	
+		
+	//only apply downtime on regular waves	
+	if (attkWave%PAUSE_WAVE_COUNT != 0) then {
 	sleep _downTime;
+	};
+
 };

--- a/resumeWave.sqf
+++ b/resumeWave.sqf
@@ -1,0 +1,20 @@
+/**
+*  resumeWave.sqf
+*
+* Restarts the waves of enemies
+*
+*  Domain: Client
+**/
+
+_resumeAction = _this select 2;
+
+WAVE_PAUSED=false; 
+
+["<t color='#ff0000' size = '.8'>Warning: Hostiles Inbound.</t>",0, -1, 3, 0] remoteExec ["BIS_fnc_dynamicText", 0];
+
+[bulwarkBox, _resumeAction] remoteExec ["removeAction", 0];
+
+//show hostile warning for 3 seconds
+sleep(3);
+
+


### PR DESCRIPTION
Allows the mission to be paused between waves at a given interval from the mission params. (regroup/rebuild waves). Resume the wave by accessing the bulwark box.